### PR TITLE
Descriptive Server Outputs Added

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ jupyter==1.0.0
 # matplotlib==3.2.2
 numpy==2.0.0
 pandas==2.2.2
-pip == 22.3.1
+pip==22.3.1
 torch==2.4.1
 torchaudio
 torchtext

--- a/run_training_server.py
+++ b/run_training_server.py
@@ -4,7 +4,27 @@ from src import model_two_hands
 from src import process_data
 import os
 import shutil
+import socket
 app = Flask(__name__)
+
+def print_connection_instructions(port):
+    hostname = socket.gethostname()
+    local_ip = socket.gethostbyname(hostname)
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(("8.8.8.8", 80))
+        lan_ip = s.getsockname()[0]
+        s.close()
+    except Exception:
+        lan_ip = local_ip
+    print("\n" + "="*60)
+    print("Flask server is starting!\n")
+    print(f"Paste this address into the Uri field in Unity if you’re using the Meta XR Simulator on your computer, or a headset plugged into your computer in Link Mode:\n")
+    print(f"    http://127.0.0.1:{port}\n")
+    print(f"Paste this address into the Uri field in Unity if you’re using an unplugged headset on the same WiFi network as your computer:\n")
+    print(f"    http://{lan_ip}:{port}\n")
+    print("="*60 + "\n")
+
 
 
 @app.route('/train_model_one_hand/', methods=['POST'])
@@ -44,6 +64,7 @@ def clearServerData():
 
 
 
-
-
-app.run(port="8080", host="0.0.0.0", debug=True)
+if __name__ == "__main__":
+    port = 8080
+    print_connection_instructions(port)
+    app.run(port=port, host="0.0.0.0", debug=True)


### PR DESCRIPTION
The server now outputs the following message when starting:

-----------------------------------------------
Flask server is starting!

Paste this address into the Uri field in Unity if you’re using the Meta XR Simulator on your computer, or a headset plugged into your computer in Link Mode
http://127.0.0.1:{port}
Paste this address into the Uri field in Unity if you’re using an unplugged headset on the same WiFi network as your computer:
http://{lan_ip}:{port}
-----------------------------------------------

Link to original ticket: https://uwrl.notion.site/11ebc072402f81feb5d7f13de9ea5b56?v=11ebc072402f81bba16f000c709aebde&p=1a0bc072402f800a91bef04bcae6a09c&pm=s